### PR TITLE
Route prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Tray Login Component
-Web Component para realizar login no Checkout das lojas da Tray.
+Web Component para realizar login nas lojas da Tray.
 
 ## Instalação
 
@@ -15,6 +15,7 @@ data-texts    | Textos personalizados (opcional)
 data-email    | E-mail utilizado para login (opcional)
 data-cpf      | CPF utilizado para login (opcional)
 data-cnpj     | CNPJ utilizado para login (opcional)
+data-route-prefix | Prefixo da rota das APIS, ex: /checkout
 
 ## Eventos
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ data-texts    | Textos personalizados (opcional)
 data-email    | E-mail utilizado para login (opcional)
 data-cpf      | CPF utilizado para login (opcional)
 data-cnpj     | CNPJ utilizado para login (opcional)
-data-route-prefix | Prefixo da rota das APIS, ex: /checkout
+data-route-prefix | Prefixo da rota das APIs, ex: checkout
 
 ## Eventos
-
 Lista de eventos disparados pelo componente.
 
 Evento              | Descrição
@@ -75,6 +74,7 @@ $(window).on('tray-login', function(event) {
 <tray-login
     data-methods="['password', 'facebook', 'otp', 'identify']"
     data-callback="/callback.html"
+    data-route-prefix="checkout"
     data-store="351572"
     data-texts="{}">
 </tray-login>

--- a/dist/tray-login.html
+++ b/dist/tray-login.html
@@ -494,6 +494,8 @@ var Zepto=function(){function L(t){return null==t?String(t):j[S.call(t)]||"objec
         this.preventDefaultMessages();
         this.setMessages();
 
+        this.routes.prefix = this.getAttribute('data-route-prefix') || this.routes.prefix;
+
         if (!initialized) {
             this.addListeners();
             this.langs.methods.get();
@@ -1205,15 +1207,16 @@ var Zepto=function(){function L(t){return null==t?String(t):j[S.call(t)]||"objec
      */
     var self;
     trayLoginProto.routes = self = {
+        prefix: 'checkout',
         routes: {
-            "has_account": "/checkout/has-account",
-            "password": "/checkout/password",
-            "password_recovery": "/checkout/password-recovery",
-            "otp": "/checkout/otp-generate",
-            "otp_login": "/checkout/otp",
-            "facebook": "/checkout/facebook/url",
-            "check_status": "/checkout/check-status",
-            "langs": "/checkout/langs/login_component",
+            "has_account": "/has-account",
+            "password": "/password",
+            "password_recovery": "/password-recovery",
+            "otp": "/otp-generate",
+            "otp_login": "/otp",
+            "facebook": "/facebook/url",
+            "check_status": "/check-status",
+            "langs": "/langs/login_component",
         },
 
         /**
@@ -1232,7 +1235,7 @@ var Zepto=function(){function L(t){return null==t?String(t):j[S.call(t)]||"objec
                     return false;
                 }
 
-                return self.routes[name];
+                return '/' + self.prefix + self.routes[name];
             },
 
             /**

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <tray-login
         data-store="351572"
         data-session="123"
+        data-route-prefix="checkout"
         data-methods="['password', 'facebook', 'otp', 'identify']"
         data-texts='{"main-action":"Mensagem!", "general-error-alert": "Erro!"}'
         data-callback="/callback.html">

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -6,15 +6,16 @@
      */
     var self;
     trayLoginProto.routes = self = {
+        prefix: 'checkout',
         routes: {
-            "has_account": "/checkout/has-account",
-            "password": "/checkout/password",
-            "password_recovery": "/checkout/password-recovery",
-            "otp": "/checkout/otp-generate",
-            "otp_login": "/checkout/otp",
-            "facebook": "/checkout/facebook/url",
-            "check_status": "/checkout/check-status",
-            "langs": "/checkout/langs/login_component",
+            "has_account": "/has-account",
+            "password": "/password",
+            "password_recovery": "/password-recovery",
+            "otp": "/otp-generate",
+            "otp_login": "/otp",
+            "facebook": "/facebook/url",
+            "check_status": "/check-status",
+            "langs": "/langs/login_component",
         },
 
         /**
@@ -33,7 +34,7 @@
                     return false;
                 }
 
-                return self.routes[name];
+                return '/' + self.prefix + self.routes[name];
             },
 
             /**

--- a/src/tray-login.js
+++ b/src/tray-login.js
@@ -43,6 +43,8 @@ var trayLoginProto = {},
         this.preventDefaultMessages();
         this.setMessages();
 
+        this.routes.prefix = this.getAttribute('data-route-prefix') || this.routes.prefix;
+
         if (!initialized) {
             this.addListeners();
             this.langs.methods.get();


### PR DESCRIPTION
Abre a possibilidade de alterar o prefixo de rotas utilizado pelo componente.
Ex:

```
<tray-login
  data-route-prefix="custom-route">
</tray-login>
```

Rotas das APIs:
```
/custom-route/has-account?email=teste@tray.com.br
/custom-route/langs/login_component
```