### PR TITLE
Fix firefox - #51964

### DIFF
--- a/dist/tray-login.html
+++ b/dist/tray-login.html
@@ -131,7 +131,7 @@ tray-login .tray-loading {
   z-index: 1; }
   tray-login .tray-loading.tray-loading-hidden {
     opacity: 0 !important;
-    z-index: -1; }
+    z-index: -1 !important; }
 
 tray-login .tray-loading-mask {
   -webkit-transform-origin: 30px 30px;

--- a/src/sass/_loading.scss
+++ b/src/sass/_loading.scss
@@ -41,7 +41,7 @@ tray-login {
 
         &.tray-loading-hidden {
             opacity: 0 !important;
-            z-index: -1;
+            z-index: -1 !important;
         }
     }
 


### PR DESCRIPTION
Adicionado important na propriedade z-index quando a classe hidden é inserida no loading.