### PR TITLE
Não retornar o token na url de callback quando o mesmo não existir

### DIFF
--- a/dist/tray-login.html
+++ b/dist/tray-login.html
@@ -1125,15 +1125,19 @@ var Zepto=function(){function D(t){return null==t?String(t):j[T.call(t)]||"objec
      * @param {string} token
      */
     trayLoginProto.redirectOnSuccess = function(token) {
-        var redirectParam = '?token=' + token;
         var callback = thisElement.getAttribute('data-callback');
 
         if (!callback) {
             return;
         }
 
-        if (callback.indexOf('?') > -1) {
-            redirectParam = '&token=' + token;
+        var redirectParam = '';
+
+        if (token) {
+            redirectParam = '?token=' + token;
+            if (callback.indexOf('?') > -1) {
+                redirectParam = '&token=' + token;
+            }
         }
 
         window.location = callback + redirectParam;

--- a/src/tray-login.js
+++ b/src/tray-login.js
@@ -675,15 +675,19 @@ var trayLoginProto = {},
      * @param {string} token
      */
     trayLoginProto.redirectOnSuccess = function(token) {
-        var redirectParam = '?token=' + token;
         var callback = thisElement.getAttribute('data-callback');
 
         if (!callback) {
             return;
         }
 
-        if (callback.indexOf('?') > -1) {
-            redirectParam = '&token=' + token;
+        var redirectParam = '';
+
+        if (token) {
+            redirectParam = '?token=' + token;
+            if (callback.indexOf('?') > -1) {
+                redirectParam = '&token=' + token;
+            }
         }
 
         window.location = callback + redirectParam;


### PR DESCRIPTION
Estava acontecendo do usuário fazer login pelo próprio EasyCheckout e o token (jwt) ser retornado na Url, sem necessidade.

Como o parâmetro `&token` já vai ser usado pelo redirect do commerce para o easy, estava conflitando.