### PR TITLE
#327 - Evitando seletores da loja de temas

### DIFF
--- a/dist/tray-login.html
+++ b/dist/tray-login.html
@@ -40,7 +40,7 @@ tray-login .tray-input {
   font-weight: 300;
   height: 47px;
   line-height: 14px;
-  padding: 13px 0 14px 36px;
+  padding: 13px 0 14px 36px !important;
   width: 100%; }
   tray-login .tray-input:focus {
     outline: none;

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -32,7 +32,7 @@ tray-login {
         font-weight: 300;
         height: 47px;
         line-height: 14px;
-        padding: 13px 0 14px 36px;
+        padding: 13px 0 14px 36px !important; //!Important necessário devido aos seletores dos tema default [loja-temas]
         width: 100%;
 
         &:focus {


### PR DESCRIPTION
Posicionamento errado do ícone de email no tray login, o problema é causado devido ao seletores da pagina de login do tema default **[Loja de Temas]** 

![image](https://cloud.githubusercontent.com/assets/7130956/26418956/855b03a4-4094-11e7-847f-6e0015c9b395.png)
