### PR TITLE
Ajuste versão 1.6.4 para 1.6.5 no package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tray-login",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "",
   "main": "gulpfile.js",
   "scripts": {


### PR DESCRIPTION
Ajuste versão 1.6.4 para 1.6.5 no package.json para condizer com a versão da tag.