### PR TITLE
Bloqueio de usuario

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -39,6 +39,37 @@
         </button>
       </app-main>
 
+      <section v-if="screen === 'Blocked'">
+        <header>
+          <strong class="tray-title tray-login__title">
+            {{ texts['main-title'] || 'Autenticação' }}
+          </strong>
+          <p class="tray-action tray-error-message">
+            {{
+              texts['blocked-user'] ||
+              'Por motivos de segurança bloqueamos o acesso por e-mail e senha durante 60 minutos.'
+            }}
+          </p>
+        </header>
+
+        <p class="tray-action">
+          {{ texts['main-action'] || 'Não foi possível verificar seu cadastro, tente novamente.' }}
+        </p>
+        <app-facebook-login v-if="facebookEnabled"
+          :callback="callback"
+          :defaultActions="defaultActions"
+          :params="params"
+          slot="app-facebook-login">
+        </app-facebook-login>
+
+        <button v-if="identificationEnabled"
+          class="tray-btn-default"
+          @click="reset"
+          slot="back-step">
+          Voltar
+        </button>
+      </section>
+      
       <section class="tray-loading" v-show="loading">
         <div class="tray-loading-mask">
           <div class="tray-loading-line"></div>
@@ -212,6 +243,7 @@ export default {
 
   methods: {
     ...mapActions([
+      'clearErrors',
       'setScreen',
       'setIdentification',
     ]),
@@ -270,6 +302,7 @@ export default {
 
       this.setScreen('Identification');
       this.setIdentification('');
+      this.clearErrors();
     },
   },
 };

--- a/src/api/mock/data/check-status-blocked.json
+++ b/src/api/mock/data/check-status-blocked.json
@@ -1,0 +1,9 @@
+{
+    "data": {
+        "data": {
+            "blocked": true,
+            "message": "Por motivos de segurança bloqueamos o acesso por senha durante 60 minutos."
+        }
+    },
+    "statusCode": 200
+}

--- a/src/api/mock/data/check-status.json
+++ b/src/api/mock/data/check-status.json
@@ -1,0 +1,8 @@
+{
+    "data": {
+        "data": {
+            "blocked": false
+        }
+    },
+    "statusCode": 200
+}

--- a/src/api/mock/index.js
+++ b/src/api/mock/index.js
@@ -1,9 +1,13 @@
+import checkStatusSuccess from './data/check-status.json';
+import checkStatusBlocked from './data/check-status-blocked.json';
+
 import facebookResponse from './data/facebook.json';
-import hasAccountResponse from './data/has-account.json';
-import hasAccountResponseError from './data/error/has-account.json';
 
 import passwordLoginSucces from './data/password.json';
 import passwordLoginError from './data/error/password.json';
+
+import hasAccountResponse from './data/has-account.json';
+import hasAccountResponseError from './data/error/has-account.json';
 
 /**
  * Cria uma promisse para o mock desejado
@@ -11,7 +15,7 @@ import passwordLoginError from './data/error/password.json';
  * @param {number} delay em milisegundos
  */
 // eslint-disable-next-line
-const fetch = (mockData, delay = 0, isValid) => {
+const fetch = (mockData, delay = 0, isValid = true) => {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       if (!isValid) {
@@ -23,11 +27,31 @@ const fetch = (mockData, delay = 0, isValid) => {
   });
 };
 
+const users = [
+  'teste@tray.com.br',
+  'usuariobloqueado@tray.com.br',
+];
+
+const blockedusers = [
+  'usuariobloqueado@tray.com.br',
+];
+
 /**
  * Retorna os mocks com o delay definido
  * @return {obj} response
  */
 export default {
+  checkUserStatus(endpoint, params) {
+    const { identification } = params;
+    let mockData = checkStatusSuccess;
+
+    if (blockedusers.indexOf(identification) !== -1) {
+      mockData = checkStatusBlocked;
+    }
+
+    return fetch(mockData, 1000);
+  },
+
   facebookLogin() {
     return fetch(facebookResponse, 1000).then(response => response);
   },
@@ -37,7 +61,7 @@ export default {
     let isValid = false;
     let mockData = hasAccountResponseError;
 
-    if (identification === 'teste@tray.com.br') {
+    if (users.indexOf(identification) !== -1) {
       isValid = true;
       mockData = hasAccountResponse;
     }

--- a/src/api/server/index.js
+++ b/src/api/server/index.js
@@ -7,6 +7,16 @@ export default {
    * @param {object} params
    * @returns {Promise}
    */
+  checkUserStatus(endpoint, params) {
+    return http.get(endpoint, { params }).then(response => response);
+  },
+
+  /**
+   * Realiza um get para o endpoint configurado
+   * @param {string} endpoint
+   * @param {object} params
+   * @returns {Promise}
+   */
   facebookLogin(endpoint, params) {
     return http.get(endpoint, { params }).then(response => response);
   },

--- a/src/components/FacebookLogin.vue
+++ b/src/components/FacebookLogin.vue
@@ -84,7 +84,7 @@ export default {
 
         this.setLoading(false);
 
-        throw error;
+        return error;
       });
     },
   },

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import { httpPlugin, eventBus } from '@/plugins';
+import store from './store';
 
 /**
  * Componente centralizador
@@ -7,7 +8,7 @@ import { httpPlugin, eventBus } from '@/plugins';
 import App from './App.vue';
 
 Vue.config.productionTip = false;
-Vue.use(httpPlugin);
+Vue.use(httpPlugin, { store });
 Vue.use(eventBus);
 
 if (process.env.NODE_ENV === 'development') {

--- a/src/plugins/http/index.js
+++ b/src/plugins/http/index.js
@@ -8,8 +8,8 @@ export const http = axios.create({
 /**
  * Define o plugin Axios como propriedade do Vue
  */
-export default function install(Vue) {
-  interceptors(http);
+export default function install(Vue, { store }) {
+  interceptors(http, store);
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty
   Object.defineProperties(Vue.prototype, {
     $http: {

--- a/src/plugins/http/interceptors.js
+++ b/src/plugins/http/interceptors.js
@@ -1,4 +1,4 @@
-export default (http) => {
+export default (http, store) => {
   // https://github.com/mzabriskie/axios#interceptors
   http.interceptors.response.use(
     response => response,
@@ -8,6 +8,10 @@ export default (http) => {
      */
     (error) => {
       const { response } = error;
+
+      if ([403].indexOf(response.status) !== -1) {
+        store.dispatch('setScreen', 'Blocked');
+      }
 
       return Promise.reject(response);
     },

--- a/src/screens/Identification.vue
+++ b/src/screens/Identification.vue
@@ -150,7 +150,7 @@ export default {
           this.setError(this.texts.errors['not-found']);
           this.setLoading(false);
 
-          throw error;
+          return error;
         });
     },
   },

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -3,6 +3,24 @@ import client from 'api-client';
 
 export default {
   /**
+   * Verifica o status do usuário
+   * @param {function} commit
+   */
+  checkUserStatus({ commit }, payload = {
+    endpoint: 'check-status',
+    identification: '',
+    identification_type: '',
+    store_id: '',
+  }) {
+    /* eslint no-unused-vars: ["error", { "args": "none" }] */
+    const { endpoint, ...params } = payload;
+
+    return client.checkUserStatus(endpoint, params)
+      .then(response => response)
+      .catch((error) => { throw error; });
+  },
+
+  /**
    * Dispara a ação para remover os erros da aplicação
    * @param {function} commit
    */
@@ -11,7 +29,7 @@ export default {
   },
 
   /**
-   * Dispara a ação para definir a identificação do usuario
+   * Verifica se o usuário possui uma conta
    * @param {function} commit
    * @param {object} payload
    */

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -4,7 +4,6 @@ import { isValidCpf, isValidCnpj } from '@brazilian-utils/validators';
  * Retorna o tipo da identificação preenchida pelo usuário
  * @param {object} state
  */
-// eslint-disable-next-line
 export const identificationType = (state) => {
   let type = 'email';
 
@@ -18,3 +17,10 @@ export const identificationType = (state) => {
 
   return type;
 };
+
+/**
+ * Retorna o ultimo erro definido na aplicação
+ * @param {object} state
+ * @return {string} html error
+ */
+export const lastError = state => state.errors[state.errors.length - 1];


### PR DESCRIPTION
## Contexto

**Por que essa mudança é necessária?**

Para identificar e bloquear os usuários que realizaram mais de *5 tentativas* de login utilzando uma senha inválida

**Como o problema foi atacado?**

sempre que a tela principal `(Main)` é "montada" disparamos uma requisição para a api `check-status` que retornará se o usuário identificado está ou não bloqueado, caso esteja trocamos a tela para `(Blocked) `impossibilitando o login por E-mail(CPF ou CNPJ)

![image](https://user-images.githubusercontent.com/7130956/54564188-e746fa80-49a9-11e9-91b5-7c088ee341cd.png)


Caso alguma requisição retorne o status `403` o usuário também será definido como bloqueado.

![image](https://media.giphy.com/media/1fnx9pVgHSEDwj3XNT/giphy.gif)

## Critérios de aceite
* [ ] - O código que eu adicionei está coberto
* [x] - Um humano testou manualmente
