### PR TITLE
Atualização da versão | Foco no input de todas as telas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tray-login",
-  "version": "2.0.0-rc.10",
+  "version": "2.0.0-rc.11",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --target wc --name tray-login 'src/main.js'",


### PR DESCRIPTION
### Desenvolvimento

Ficou faltando atualizar a versão do `package.json` no MR anterior, este ajuste é necessário para manter a versão da release.