### PR TITLE
Falha#4507 - Modal de login não cabe na tela do dispositivo

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="tray-container"
-    v-bind:class="{ 'tray-container__identify': screen === 'Identification' }"
     ref="tray-login" v-show="showComponent">
     <button class="tray-close"
       @click="close">

--- a/src/assets/sass/layout/_base.scss
+++ b/src/assets/sass/layout/_base.scss
@@ -55,14 +55,13 @@ tray-login {
         border: 1px solid $overlay-color;
         width: 292px;
         position: fixed;
-        left: calc(50% - 146px);
-        top: calc(50% - 300px);
         padding: $default-gutter;
         z-index: 9999;
-
-        &.tray-container__identify {
-            top: calc(50% - 120px);
-        }
+        transform: translate(-50%, -50%);
+        top: 50%;
+        left: 50%;
+        max-height: 100%;
+        overflow: auto;
     }
 
     .tray-close {

--- a/src/screens/Login/screens/RecoverPassword/screens/New.vue
+++ b/src/screens/Login/screens/RecoverPassword/screens/New.vue
@@ -6,7 +6,7 @@
         {{ $lang['new-password-title']}}
       </strong>
       <div class="tray-login__recover-password__header">
-        <figure class="tray-login__recover-password__figure">
+        <figure class="tray-login__recover-password__figure" v-show="shouldShowIcon">
           <svg class="tray-user-lock" viewBox="0 0 640 512">
             <!-- eslint-disable-next-line -->
             <path class="path1" d="M224 256A128 128 0 1 0 96 128a128 128 0 0 0 128 128zm96 64a63.08 63.08 0 0 1 8.1-30.5c-4.8-.5-9.5-1.5-14.5-1.5h-16.7a174.08 174.08 0 0 1-145.8 0h-16.7A134.43 134.43 0 0 0 0 422.4V464a48 48 0 0 0 48 48h280.9a63.54 63.54 0 0 1-8.9-32zm288-32h-32v-80a80 80 0 0 0-160 0v80h-32a32 32 0 0 0-32 32v160a32 32 0 0 0 32 32h224a32 32 0 0 0 32-32V320a32 32 0 0 0-32-32zM496 432a32 32 0 1 1 32-32 32 32 0 0 1-32 32zm32-144h-64v-80a32 32 0 0 1 64 0z"></path>
@@ -183,6 +183,14 @@ export default {
     ...mapState('Login/RecoverPassword', [
       'password',
     ]),
+
+    /**
+     * Verifica a altura do dispositivo para definir se deve mostrar o icone de cadeado
+     * @return {boolean}
+     */
+    shouldShowIcon() {
+      return window.innerHeight >= 640;
+    },
 
     /**
      * Estado mapeado da vuex,


### PR DESCRIPTION
**Alterações**
- Foi adicionado uma função computada `shouldShowIcon` , que define se o icone de cadeado da tela de redefinir senha deve aparecer em dispositivos que tem altura menor ou igual a 640px

- Foi simplificado a forma em que a classe `tray-container` centraliza o conteúdo na tela, e agora ela deixa os componentes _scrollaveis_ caso algum conteúdo exceda o tamanho da tela